### PR TITLE
src/cmd: introduce info subcommand

### DIFF
--- a/src/cmd/info.rs
+++ b/src/cmd/info.rs
@@ -1,0 +1,50 @@
+// 3rd party imports {{{
+use clap::Clap;
+use raur::Raur;
+// }}}
+
+// Pretty print lists
+macro_rules! printlist {
+    ($h:expr, $v:expr) => {{
+        println!("{}", $h);
+        for v in $v {
+            println!("{:indent$}{}", "", v, indent=2)
+        }
+    }};
+}
+
+#[derive(Clap)]
+pub struct CliArgs {
+    packages: Vec<String>,
+}
+
+pub async fn handler(args: CliArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let raur = raur::Handle::new();
+
+    // TODO: check if all packages were found
+    // raur.info doesn't return any errors if the package isn't found
+    let packages = raur.info(&args.packages).await?;
+
+    for package in packages {
+        println!("Repository: aur");
+        println!("Name: {}", &package.name);
+        println!("Version: {}", &package.version);
+        println!("Description: {}", &package.description.unwrap_or("".to_string()));
+        println!("URL: {}", &package.url.unwrap_or("".to_string()));
+        println!("Maintainer: {}", &package.maintainer.unwrap_or("".to_string()));
+        printlist!("Groups:", &package.groups);
+        printlist!("Licenses:", &package.license);
+        printlist!("Provides:", &package.provides);
+        printlist!("Depends on:", &package.depends);
+        printlist!("Make dependencies:", &package.make_depends);
+        printlist!("Check dependencies:", &package.check_depends);
+        printlist!("Optional dependencies:", &package.opt_depends);
+        printlist!("Conflicts with:", &package.conflicts);
+        println!("Votes: {}", &package.num_votes.to_string());
+        println!("Popularity: {}", &package.popularity.to_string());
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,1 +1,2 @@
+pub mod info;
 pub mod search;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod cmd;
 
 #[derive(Clap)]
 enum SubCommand {
+    Info(cmd::info::CliArgs),
     Search(cmd::search::CliArgs),
 }
 
@@ -28,6 +29,7 @@ async fn main() {
     let args = CliArgs::parse();
 
     let result = match args.subcmd {
+        SubCommand::Info(args) => cmd::info::handler(args).await,
         SubCommand::Search(args) => cmd::search::handler(args).await,
     };
 


### PR DESCRIPTION
Introduce an `info` subcommand.

This command will fetch information about the package from AUR (given
that it exists), and print it to stdout.
